### PR TITLE
generated url should be returned

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -5,7 +5,7 @@ export function cloudinaryConfig(config) {
 }
 
 export function cloudinaryUrl(publicId, options) {
-  cloudinary.url(publicId, options);
+  return cloudinary.url(publicId, options);
 }
 
 export CloudinaryImage from './CloudinaryImage';


### PR DESCRIPTION
This exported function wraps the url generation function but must also return its result.