### PR TITLE
Make video element into div node to eliminate error

### DIFF
--- a/lib/CloudinaryVideo.js
+++ b/lib/CloudinaryVideo.js
@@ -33,8 +33,9 @@ var CloudinaryVideo = (function (_Component) {
     var _props = this.props;
     var publicId = _props.publicId;
     var options = _props.options;
-
-    this.refs.video.insertBefore(cloudinary.video(publicId, options), null);
+    var videoNode = document.createElement('div');
+    videoNode.innerHTML = cloudinary.video(publicId, options);
+    this.refs.video.insertBefore(videoNode, null);
   };
 
   CloudinaryVideo.prototype.render = function render() {


### PR DESCRIPTION
I installed the library and got the same error as: https://github.com/seokgyo/react-cloudinary/issues/2

This fix seems to be working for me.